### PR TITLE
implemented IntoRawBytes for Rgb666 

### DIFF
--- a/src/raw_framebuf.rs
+++ b/src/raw_framebuf.rs
@@ -103,6 +103,17 @@ impl IntoRawBytes for embedded_graphics::pixelcolor::Rgb565 {
     }
 }
 
+impl IntoRawBytes for embedded_graphics::pixelcolor::Rgb666 {
+    const BYTES_PER_PIXEL: usize = 3;
+    type Raw = [u8; 3];
+
+    //scale up by 8bits/ 6bits = 256/64 = 4
+    fn into_raw_bytes(self) -> <Self as IntoRawBytes>::Raw {
+        [self.r()* 4, self.g() *4, self.b()*4]
+    }
+}
+
+
 impl IntoRawBytes for embedded_graphics::pixelcolor::Rgb888 {
     const BYTES_PER_PIXEL: usize = 3;
     type Raw = [u8; 3];


### PR DESCRIPTION
implemented IntoRawBytes for Rgb666 
colours were desaturated so scaled up values by 4