### PR TITLE
fix(example): initialize frame buffer with init_with

### DIFF
--- a/examples/spi-st7789-esp32-c3/src/main.rs
+++ b/examples/spi-st7789-esp32-c3/src/main.rs
@@ -117,7 +117,7 @@ async fn main(_spawner: Spawner) {
     info!("Display initialized!");
 
     // Initialize frame buffer
-    let frame_buffer = FRAME_BUFFER.init([0; FRAME_SIZE]);
+    let frame_buffer = FRAME_BUFFER.init_with(|| [0; FRAME_SIZE]);
 
     // Create a framebuffer for drawing
     let mut raw_fb =


### PR DESCRIPTION
This avoids errors when the frame buffer is too large to be moved from the stack. Instead the frame buffer is initialized in place (see [docs](https://docs.rs/static_cell/latest/static_cell/struct.StaticCell.html#method.init_with)).